### PR TITLE
Account for reviews requesting changes

### DIFF
--- a/merge-pull-request
+++ b/merge-pull-request
@@ -123,7 +123,7 @@ main() {
 
     for user in "${!approvals[@]}"; do
       if [[ ! "${approvals[$user]}" = true ]]; then
-        echo "Not mergeing pull request #${number}, because @${user} requested changes."
+        echo "Not merging pull request #${number}, because @${user} requested changes."
         ctr=$((ctr+1))
         continue
       fi

--- a/merge-pull-request
+++ b/merge-pull-request
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -o pipefail
@@ -99,24 +99,35 @@ main() {
     local numreviews
     numreviews=$(echo "$reviews" | jq '. | length')
 
-    local approvals=0
+    declare -A approvals
     local j=0
     while [ "$j" -lt "$numreviews" ]; do
       review=$(echo "$reviews" | jq --raw-output ".[$j]")
-      state=$(echo "$review" | jq --raw-output '.state')
+      user=$(echo "$review" | jq --raw-output ".user.login")
+      state=$(echo "$review" | jq --raw-output ".state")
 
       if [[ "$state" == "APPROVED" ]]; then
-        approvals=$((approvals+1))
+        approvals[$user]=true
+      elif [[ "$state" == "CHANGES_REQUESTED" ]]; then
+        approvals[$user]=false
       fi
 
       j=$((j+1))
     done
 
-    if [[ "$approvals" -lt 1 ]]; then
+    if [[ "${#approvals[@]}" -lt 1 ]]; then
       echo "Could not find any reviews approving pull request #${number}."
       ctr=$((ctr+1))
       continue
     fi
+
+    for user in "${!approvals[@]}"; do
+      if [[ ! "${approvals[$user]}" = true ]]; then
+        echo "Not mergeing pull request #${number}, because @${user} requested changes."
+        ctr=$((ctr+1))
+        continue
+      fi
+    done
 
     echo "Merging pull request #${number}..."
 

--- a/test/bin/curl
+++ b/test/bin/curl
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # TODO: Hacky way to detect when running interactively
-if [ -t 0 ]; then
+if read -t 0; then
   echo ""
   # running interactivelly
 else
@@ -15,6 +15,16 @@ args="$*"
 
 if [[ "$args" == *"open"* ]]; then
   echo '[{ "number": 2, "head": { "sha": "shafoobarbaz" }, "labels": [{"name": "baz"}] },{ "number": 1, "head": { "sha": "shafoobarbaz" }, "labels": [{"name": "baz"}] }]'
+
 elif [[ "$args" == *"reviews"* ]]; then
-  echo '[{"state": "meh"},{"state": "baz"},{"state": "APPROVED"}]'
+  if [ -n "$NO_REVIEWS" ]; then
+    echo "[]"
+  else
+  echo '['\
+    '{"user": {"login": "user_a"}, "state": "CHANGES_REQUESTED"},'\
+    '{"user": {"login": "user_b"}, "state": "APPROVED"},'\
+    '{"user": {"login": "user_a"}, "state": "APPROVED"}'\
+    ']'
+  fi
+
 fi

--- a/test/bootstrap.bash
+++ b/test/bootstrap.bash
@@ -2,4 +2,4 @@
 
 set -e
 
-# apt update && apt install --no-install-recommends -y jq >&2
+apt update && apt install --no-install-recommends -y jq >&2

--- a/test/bootstrap.bash
+++ b/test/bootstrap.bash
@@ -2,4 +2,4 @@
 
 set -e
 
-apt update && apt install --no-install-recommends -y jq >&2
+apt update && apt install --no-install-recommends -y jq > /dev/null 2>&1

--- a/test/merge-pull-request.bats
+++ b/test/merge-pull-request.bats
@@ -2,7 +2,7 @@
 
 load bootstrap
 
-PATH="$PATH:$BATS_TEST_DIRNAME/bin"
+PATH="$BATS_TEST_DIRNAME/bin:$PATH"
 
 function setup() {
   export WORKSPACE="${WORKSPACE-"${BATS_TEST_DIRNAME}/.."}"
@@ -15,6 +15,8 @@ function teardown() {
   unset "${!MERGE_LABEL@}"
   unset "${!TOKEN@}"
   unset "${!GITHUB_TOKEN@}"
+
+  unset "${!NO_REVIEWS@}"
 }
 
 @test "open pull requests with merge label get merged" {
@@ -25,4 +27,15 @@ function teardown() {
   grep "Merging pull request #1" "$stdoutPath"
 
   grep "Foo merged" "$stdoutPath"
+}
+
+@test "open pull request with no reviews does not get merged" {
+  local stdoutPath="${BATS_TMPDIR}/${BATS_TEST_NAME}_1.stdout"
+
+  export NO_REVIEWS=1
+
+  "$WORKSPACE/merge-pull-request" 1>${stdoutPath}
+
+  grep "Could not find any reviews approving pull request #2." "$stdoutPath"
+  grep "Could not find any reviews approving pull request #1." "$stdoutPath"
 }


### PR DESCRIPTION
The script would merge a pull request as long as it had at least one approval. It did not take into account subsequent reviews (or reviews by other reviewers) that requested changes.

This has been addressed by first collecting the final approval statuses of all reviewers, and then looping over it to see whether all reviewers have approved the pull request.